### PR TITLE
Update sqlcipher to latest and add icu support

### DIFF
--- a/rpm/sqlcipher.spec
+++ b/rpm/sqlcipher.spec
@@ -10,6 +10,7 @@ BuildRequires: glibc-devel
 BuildRequires: autoconf
 BuildRequires: openssl-devel
 BuildRequires: tcl-devel
+BuildRequires: pkgconfig(icu-i18n)
 
 %description
  SQLCipher is a C library that implements an encryption in the SQLite 3
@@ -53,8 +54,8 @@ autoreconf -vfi
     --disable-readline          \
     --disable-tcl               \
     --enable-tempstore=yes      \
-    CFLAGS="-DSQLITE_HAS_CODEC" \
-    LDFLAGS="-lcrypto"
+    CFLAGS="-DSQLITE_HAS_CODEC -DSQLITE_ENABLE_ICU" \
+    LDFLAGS="`icu-config --ldflags-libsonly`"
 make %{?_smp_mflags}
 
 %install

--- a/rpm/sqlcipher.spec
+++ b/rpm/sqlcipher.spec
@@ -1,6 +1,6 @@
 Summary: AES encryption for SQLite databases
 Name: sqlcipher
-Version: 3.4.1
+Version: 4.5.0
 Release: 1
 License: BSD
 Group: Applications/Databases
@@ -72,13 +72,13 @@ install -D -m0644 sqlcipher.1 %{buildroot}/%{_mandir}/man1/sqlcipher.1
 %doc README.md
 %{_bindir}/sqlcipher
 %{_libdir}/*.so.*
-%{_mandir}/man?/*
 
 %files devel
 %defattr(-, root, root)
 %{_includedir}/sqlcipher/*.h
 %{_libdir}/*.so
 %{_libdir}/pkgconfig/*.pc
+%{_mandir}/man?/*
 %exclude %{_libdir}/*.a
 %exclude %{_libdir}/*.la
 


### PR DESCRIPTION
Sqlcipher was a bit lagging behind. This MR is updating it to the latest version. As far as I've understood it, sqlcipher is copying SQlite sources in itself. Using 4.5.0 ensures that we are using SQlite 3.36 consistently with the CVE fixes used by current SQlite in SailfishOS. With the previous version (3.4.0), we were using sqlite 3.20…

Besides, in sailfish secret daemon, there are always complains on `icu_load_collation()` not existing on startup. This is because sqlcipher was not compiled with the ICU extension. The second commit is adding it. Besides, we may just enable the ICU_COLLATION part and not full ICU support. What do you think ? Is it necessary to enable full ICU support, so `upper()`, `lower()`, `like` and friends will work for the locale ? Or it's a waste of resources ?

@chriadam and @pvuorela may you review this when you have time ? Thank you.